### PR TITLE
rmceertfm needs to match full function names only

### DIFF
--- a/rmceertfm
+++ b/rmceertfm
@@ -19,7 +19,7 @@ fi
 # in one 'edit' session
 #
 for e in $list; do
-  line=$(grep -n $e "${output}" | awk -F':' ' { print $1; }' )
+  line=$(grep -n "'$e'" "${output}" | awk -F':' ' { print $1; }' )
   if [ "${line}x" != "x" ]; then
     if ! sed -e "${line}d" "${output}" >"${tmp}" || ! cp "${tmp}" "${output}" || ! rm "${tmp}"; then
       echo "deletion of line ${line} (exported symbol ${e}) failed" >&2


### PR DESCRIPTION
Some of the function names that rmceertfm appear as both a full function name and part of a longer function name.
e.g.
flock and flockfile

The grep command matches both, which can cause the wrong function to be deleted.
e.g.
z/OS 2.4 only has flockfile, so that is incorrectly deleted.
z/OS 2.5 has both flock and flockfile, so the one that gets deleted is the second one (the sed command ends up as "xxx yyyd").

Adding quotes means that it only matches full function names.